### PR TITLE
update powerbar to use the power index instead of a string

### DIFF
--- a/Kui_Nameplates/elements/powerbar.lua
+++ b/Kui_Nameplates/elements/powerbar.lua
@@ -21,7 +21,7 @@ function addon.Nameplate.UpdatePowerType(f,on_show)
     f = f.parent
 
     -- get unit's primary power type
-    local power_type = select(2,UnitPowerType(f.unit))
+    local power_type, power_token = UnitPowerType(f.unit)
     local power_max = UnitPowerMax(f.unit,power_type)
 
     if power_max == 0 then
@@ -32,8 +32,8 @@ function addon.Nameplate.UpdatePowerType(f,on_show)
 
     if f.elements.PowerBar then
         -- update bar colour
-        if power_type then
-            local colour = ele.colours[power_type] or ele.colours['MANA']
+        if power_token then
+            local colour = ele.colours[power_token] or ele.colours['MANA']
             f.PowerBar:SetStatusBarColor(unpack(colour))
         else
             f.PowerBar:SetStatusBarColor(0,0,0)


### PR DESCRIPTION
UnitPower/UnitPowerMax has been silently ignoring the string power type for quite some time and just defaulted to returning the primary power value.

With Blizzard reworking some of the API with [docs and such](https://www.townlong-yak.com/framexml/ptr/Blizzard_APIDocumentation/UnitLua.lua#45), it looks like the UnitPower functions are checking arg type now, so this causes an error on the PTR 😜 

```
108x Kui_Nameplates\elements/powerbar.lua:25: Usage: local maxPower = UnitPowerMax(unitToken [, powerType, unmodified])
[C]: in function `UnitPowerMax'
Kui_Nameplates\elements/powerbar.lua:25: in function `UpdatePowerType'
Kui_Nameplates\elements/powerbar.lua:53: in function `func'
Kui_Nameplates\messages.lua:33: in function `DispatchMessage'
Kui_Nameplates\nameplate.lua:74: in function `OnShow'
Kui_Nameplates\nameplate.lua:68: in function `OnUnitAdded'
Kui_Nameplates\addon.lua:62: in function `?'
Kui_Nameplates\addon.lua:106: in function <Kui_Nameplates\addon.lua:103>
 
Locals:
(*temporary) = "nameplate1"
(*temporary) = "RAGE"
```