### PR TITLE
Update auras to red text/pulse on the pandemic refresh timer instead of 5 seconds

### DIFF
--- a/Kui_Nameplates/elements/auras.lua
+++ b/Kui_Nameplates/elements/auras.lua
@@ -136,7 +136,7 @@ local function button_OnUpdate(self,elapsed)
     self.cd_elap = (self.cd_elap or 0) - elapsed
     if self.cd_elap <= 0 then
         local remaining = self.expiration - GetTime()
-		local remainingPandemic = self.duration * 0.3
+	  local remainingPandemic = self.duration * 0.3
 
         if self.parent.pulsate and remaining <= remainingPandemic then
             self:StartPulsate()

--- a/Kui_Nameplates/elements/auras.lua
+++ b/Kui_Nameplates/elements/auras.lua
@@ -187,7 +187,7 @@ local function button_UpdateCooldown(self,duration,expiration)
     if expiration and expiration > 0 then
         self.expiration = expiration
         self.cd_elap = 0
-		self.duration = duration
+	self.duration = duration
         self:SetScript('OnUpdate',button_OnUpdate)
         self.cd:Show()
     else

--- a/Kui_Nameplates/elements/auras.lua
+++ b/Kui_Nameplates/elements/auras.lua
@@ -187,7 +187,7 @@ local function button_UpdateCooldown(self,duration,expiration)
     if expiration and expiration > 0 then
         self.expiration = expiration
         self.cd_elap = 0
-	self.duration = duration
+	  self.duration = duration
         self:SetScript('OnUpdate',button_OnUpdate)
         self.cd:Show()
     else

--- a/Kui_Nameplates/elements/auras.lua
+++ b/Kui_Nameplates/elements/auras.lua
@@ -136,8 +136,9 @@ local function button_OnUpdate(self,elapsed)
     self.cd_elap = (self.cd_elap or 0) - elapsed
     if self.cd_elap <= 0 then
         local remaining = self.expiration - GetTime()
+		local remainingPandemic = self.duration * 0.3
 
-        if self.parent.pulsate and remaining <= 5 then
+        if self.parent.pulsate and remaining <= remainingPandemic then
             self:StartPulsate()
         else
             self:StopPulsate()
@@ -164,7 +165,7 @@ local function button_OnUpdate(self,elapsed)
             self.cd_elap = .5
         end
 
-        if remaining <= 5 then
+        if remaining <= remainingPandemic then 
             self.cd:SetTextColor(1,0,0)
         elseif remaining <= 20 then
             self.cd:SetTextColor(1,1,0)
@@ -186,6 +187,7 @@ local function button_UpdateCooldown(self,duration,expiration)
     if expiration and expiration > 0 then
         self.expiration = expiration
         self.cd_elap = 0
+		self.duration = duration
         self:SetScript('OnUpdate',button_OnUpdate)
         self.cd:Show()
     else


### PR DESCRIPTION
I was going to make an issue instead but this is easier to explain what I mean.

As a druid for example, I want to know exactly when I can start refreshing my dots, for example you can start refreshing moonfire at 6.6 seconds (30% of max duration, 22sec), but it only goes red/pulses at 5 seconds without my change.

An option should be added for this probably (for people that want default behaviour), I don't know enough about LUA to add that, but it should be simple enough for you. I tested this in game and it works, moonfire goes red sooner than sunfire because it has a longer duration and so it can be refreshed earlier.