### PR TITLE
Add support for Arms/Fury Warrior Massacre talent

### DIFF
--- a/Kui_Nameplates/plugins/execute.lua
+++ b/Kui_Nameplates/plugins/execute.lua
@@ -21,6 +21,10 @@ local talents = {
         [22156] = 25, -- (guardian)
         [22367] = 25, -- (resto)
     },
+    ['WARRIOR'] = {
+        [22380] = 35, -- arms massacre
+        [22393] = 35, -- fury massacre
+    },
 }
 local pvp_talents = {
     ['WARRIOR'] = {


### PR DESCRIPTION
I tested this change myself to allow the execute range auto detect to support Arms and Fury when using Massacre (allows execute on targets 35% or below).  Sorry I keep bugging you with these but I'm new at lua coding so it's taking me a while to figure this out today.  Great addon!