### PR TITLE
Add support for Fire Mage Searing Touch talent

### DIFF
--- a/Kui_Nameplates/plugins/execute.lua
+++ b/Kui_Nameplates/plugins/execute.lua
@@ -20,6 +20,9 @@ local talents = {
     ['HUNTER'] = {
         [22291] = 35 -- Beast Mastery Killer Instinct
     },
+	['MAGE'] = {
+        [22462] = 30, -- Fire Searing Touch
+    },
     ['PRIEST'] = {
         [23125] = 35 -- Shadow Twist of Fate
     },


### PR DESCRIPTION
If the Fire Mage's "Searing Touch" talent is enabled, Scorch deals 150% increased damage and is a guaranteed Critical Strike when the target is below 30% health. 

This PR sets the execute range to 30% when "Searing Touch" is active "auto-detect range" is enabled.