### PR TITLE
Add ability to hide blizzard castbar in castbar settings

### DIFF
--- a/Kui_Nameplates_Core/config.lua
+++ b/Kui_Nameplates_Core/config.lua
@@ -191,6 +191,7 @@ local default_config = {
     auras_count_size = 0,
 
     castbar_enable = true,
+    disable_blizzard_castbar = false,
     castbar_colour = {.75,.75,.9},
     castbar_unin_colour = {.8,.3,.3},
     castbar_showpersonal = false,

--- a/Kui_Nameplates_Core/create.lua
+++ b/Kui_Nameplates_Core/create.lua
@@ -1024,7 +1024,7 @@ do
 end
 -- castbar #####################################################################
 do
-    local CASTBAR_ENABLED,CASTBAR_HEIGHT,CASTBAR_COLOUR,CASTBAR_UNIN_COLOUR,
+    local CASTBAR_ENABLED,DISABLE_BLIZZARD_CASTBAR,CASTBAR_HEIGHT,CASTBAR_COLOUR,CASTBAR_UNIN_COLOUR,
           CASTBAR_SHOW_ICON,CASTBAR_SHOW_NAME,CASTBAR_SHOW_SHIELD,
           CASTBAR_NAME_VERTICAL_OFFSET,CASTBAR_ANIMATE,
           CASTBAR_ANIMATE_CHANGE_COLOUR,CASTBAR_SPACING,SHIELD_H,SHIELD_W,
@@ -1174,6 +1174,26 @@ do
         end
     end
     local function UpdateCastBar(f)
+        if DISABLE_BLIZZARD_CASTBAR then
+            CastingBarFrame.RegisterEvent = function() end
+            CastingBarFrame:UnregisterAllEvents()
+            CastingBarFrame:Hide()
+        else
+            CastingBarFrame.RegisterEvent = nil
+            CastingBarFrame:UnregisterAllEvents()
+            CastingBarFrame:RegisterUnitEvent("UNIT_SPELLCAST_START", "player")
+            CastingBarFrame:RegisterUnitEvent("UNIT_SPELLCAST_STOP", "player")
+            CastingBarFrame:RegisterUnitEvent("UNIT_SPELLCAST_FAILED", "player")
+            CastingBarFrame:RegisterEvent("UNIT_SPELLCAST_INTERRUPTED")
+            CastingBarFrame:RegisterEvent("UNIT_SPELLCAST_DELAYED")
+            CastingBarFrame:RegisterEvent("UNIT_SPELLCAST_CHANNEL_START")
+            CastingBarFrame:RegisterEvent("UNIT_SPELLCAST_CHANNEL_STOP")
+            CastingBarFrame:RegisterEvent("UNIT_SPELLCAST_CHANNEL_UPDATE")
+            CastingBarFrame:RegisterEvent("UNIT_SPELLCAST_INTERRUPTIBLE")
+            CastingBarFrame:RegisterEvent("UNIT_SPELLCAST_NOT_INTERRUPTIBLE")
+            CastingBarFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
+        end
+
         if not CASTBAR_ENABLED then return end
         if f.IN_NAMEONLY and (not CASTBAR_DETACH or not CASTBAR_DETACH_NAMEONLY) then
             f.handler:DisableElement('CastBar')
@@ -1423,6 +1443,7 @@ do
 
     function core:SetCastBarConfig()
         CASTBAR_ENABLED = self.profile.castbar_enable
+        DISABLE_BLIZZARD_CASTBAR = self.profile.disable_blizzard_castbar
         CASTBAR_HEIGHT = self:Scale(self.profile.castbar_height)
         CASTBAR_COLOUR = self.profile.castbar_colour
         CASTBAR_UNIN_COLOUR = self.profile.castbar_unin_colour

--- a/Kui_Nameplates_Core_Config/create.lua
+++ b/Kui_Nameplates_Core_Config/create.lua
@@ -624,6 +624,8 @@ end
 -- cast bars ###################################################################
 function castbars:Initialise()
     local castbar_enable = self:CreateCheckBox('castbar_enable')
+    local disable_blizzard_castbar = self:CreateCheckBox('disable_blizzard_castbar')
+    disable_blizzard_castbar.require_reload = true
     local castbar_colour = self:CreateColourPicker('castbar_colour')
     local castbar_unin_colour = self:CreateColourPicker('castbar_unin_colour')
     local castbar_personal = self:CreateCheckBox('castbar_showpersonal')
@@ -649,7 +651,8 @@ function castbars:Initialise()
     castbar_icon_side.SelectTable = { 'Left','Right' } -- TODO l10n
 
     castbar_enable:SetPoint('TOPLEFT',10,-10)
-    castbar_name:SetPoint('TOPLEFT',castbar_enable,'BOTTOMLEFT')
+    disable_blizzard_castbar:SetPoint('TOPLEFT', castbar_enable, 'BOTTOMLEFT')
+    castbar_name:SetPoint('TOPLEFT',disable_blizzard_castbar,'BOTTOMLEFT')
     castbar_shield:SetPoint('TOPLEFT',castbar_name,'BOTTOMLEFT')
 
     castbar_icon:SetPoint('TOPLEFT',castbar_shield,'BOTTOMLEFT',0,0)

--- a/Kui_Nameplates_Core_Config/locale/enGB.lua
+++ b/Kui_Nameplates_Core_Config/locale/enGB.lua
@@ -230,6 +230,7 @@ L.titles = {
     auras_count_movable = 'Count',
 
     castbar_enable = 'Enable',
+    disable_blizzard_castbar = 'Disable Blizzard castbar',
     castbar_colour = 'Bar colour',
     castbar_unin_colour = 'Uninterruptible colour',
     castbar_showpersonal = 'On personal',


### PR DESCRIPTION
I loved using the castbar on my personal resource display, but found the additional Blizzard castbar to be unnecessary clutter / noise. To add further depth of customization, I added the option to disable the default castbar in the "castbar" settings portion of the addon. 

This is a relatively lightweight change. Ultimately it just adds a new checkbox, and new condition to updateCastBar that hooks / unhooks the Blizzard castbar depending on the setting.

Config look:
![image](https://user-images.githubusercontent.com/17240610/99343327-8046ac80-2842-11eb-97a3-5966be59ae5f.png)

With option disabled:
![image](https://user-images.githubusercontent.com/17240610/99343334-82107000-2842-11eb-9a02-fb519a4edeea.png)

With option enabled:
![image](https://user-images.githubusercontent.com/17240610/99343337-82a90680-2842-11eb-96f2-9bc9e42a0bed.png)
