### PR TITLE
Updating to use role detection for tankmode in WoTLK Classic 

### DIFF
--- a/Kui_Nameplates/plugins/tankmode.lua
+++ b/Kui_Nameplates/plugins/tankmode.lua
@@ -7,7 +7,7 @@ mod.colours = {
     { 1,1,0 },  -- player is gaining/losing threat
     { .6,0,1 }  -- other tank is tanking
 }
-local force_enable,force_offtank,spec_enabled,offtank_enable
+local force_enable,force_offtank,spec_enabled,offtank_enable,role_enabled
 -- local functions #############################################################
 local function UpdateFrames()
     -- update threat colour on currently visible frames
@@ -87,7 +87,7 @@ function mod:GlowColourChange(f)
     end
 
     -- tank mode health bar colours
-    if self.enabled and (force_enable or spec_enabled) and
+    if self.enabled and (force_enable or spec_enabled or role_enabled) and
         ( (f.state.threat and f.state.threat > 0) or
           f.state.tank_mode_offtank
         )
@@ -117,14 +117,8 @@ function mod:UNIT_THREAT_LIST_UPDATE(_,f,unit)
         local tank_unit = unit..'target'
 
         if UnitExists(tank_unit) and not UnitIsUnit(tank_unit,'player') then
-            local is_tank
-            if not kui.CLASSIC then -- No role data on classic, use raid roles
-                is_tank = UnitGroupRolesAssigned(tank_unit) == 'TANK'
-            else
-                is_tank = select(10, GetRaidRosterInfo(UnitInRaid(tank_unit))) == 'MAINTANK'
-            end
-
-            if ((UnitInParty(tank_unit) or UnitInRaid(tank_unit)) and is_tank) or
+            if ((UnitInParty(tank_unit) or UnitInRaid(tank_unit)) and
+                UnitGroupRolesAssigned(tank_unit) == 'TANK') or
                 (not UnitIsPlayer(tank_unit) and UnitPlayerControlled(tank_unit))
             then
                 -- unit is attacking another group tank,
@@ -139,7 +133,10 @@ function mod:UNIT_THREAT_LIST_UPDATE(_,f,unit)
 end
 function mod:SpecUpdate()
     if not self.enabled then return end
-    if kui.CLASSIC then return end -- No role data on classic
+    if kui.CLASSIC then
+        role_enabled = UnitGroupRolesAssigned('player') == 'TANK'
+        return
+    end -- XXX no spec data on classic
     local was_enabled = spec_enabled
     local spec = GetSpecialization()
     local role = spec and GetSpecializationRole(spec) or nil
@@ -154,7 +151,7 @@ function mod:GroupUpdate(_,no_update)
     -- enable/disable off-tank detection
     if not self.enabled then return end
 
-    if GetNumGroupMembers() > 0 and (spec_enabled or force_offtank) then
+    if GetNumGroupMembers() > 0 and (spec_enabled or force_offtank or role_enabled) then
         if not offtank_enable then
             offtank_enable = true
 
@@ -179,18 +176,16 @@ end
 -- register ####################################################################
 function mod:OnEnable()
     spec_enabled = false
+    role_enabled = false
 
     self:RegisterMessage('HealthColourChange')
     self:RegisterMessage('GlowColourChange')
-
     self:RegisterEvent('GROUP_ROSTER_UPDATE','GroupUpdate')
-
+    self:RegisterEvent('PLAYER_ENTERING_WORLD','SpecUpdate')
     if not kui.CLASSIC then
         self:RegisterEvent('PLAYER_SPECIALIZATION_CHANGED','SpecUpdate')
-        self:RegisterEvent('PLAYER_ENTERING_WORLD','SpecUpdate')
-
-        self:SpecUpdate()
     end
+    self:SpecUpdate()
 end
 function mod:OnDisable()
     UpdateFrames()

--- a/Kui_Nameplates/plugins/tankmode.lua
+++ b/Kui_Nameplates/plugins/tankmode.lua
@@ -135,7 +135,7 @@ function mod:SpecUpdate()
     if not self.enabled then return end
     if kui.CLASSIC then
         role_enabled = UnitGroupRolesAssigned('player') == 'TANK'
-        return
+        return 
     end -- XXX no spec data on classic
     local was_enabled = spec_enabled
     local spec = GetSpecialization()
@@ -187,12 +187,10 @@ function mod:OnEnable()
     end
     if kui.WRATH then
         self:RegisterEvent('PLAYER_ROLES_ASSIGNED','SpecUpdate')
-        self:RegisterEvent('PLAYER_TALENT_UPDATE', 'SpecUpdate')
-        self:RegisterEvent('TALENT_GROUP_ROLE_CHANGED', 'SpecUpdate')
     end
 
-    self:SpecUpdate()	
-    
+    self:SpecUpdate()
+
 end
 function mod:OnDisable()
     UpdateFrames()

--- a/Kui_Nameplates/plugins/tankmode.lua
+++ b/Kui_Nameplates/plugins/tankmode.lua
@@ -185,7 +185,14 @@ function mod:OnEnable()
     if not kui.CLASSIC then
         self:RegisterEvent('PLAYER_SPECIALIZATION_CHANGED','SpecUpdate')
     end
-    self:SpecUpdate()
+    if kui.WRATH then
+        self:RegisterEvent('PLAYER_ROLES_ASSIGNED','SpecUpdate')
+        self:RegisterEvent('PLAYER_TALENT_UPDATE', 'SpecUpdate')
+        self:RegisterEvent('TALENT_GROUP_ROLE_CHANGED', 'SpecUpdate')
+    end
+
+    self:SpecUpdate()	
+    
 end
 function mod:OnDisable()
     UpdateFrames()

--- a/Kui_Nameplates/plugins/tankmode.lua
+++ b/Kui_Nameplates/plugins/tankmode.lua
@@ -190,7 +190,6 @@ function mod:OnEnable()
     end
 
     self:SpecUpdate()
-
 end
 function mod:OnDisable()
     UpdateFrames()


### PR DESCRIPTION
This restores tank and off tank mode working when grouped with people that have their role set. 

You are the tank if your role is set to tank, and off tanks are set as long as off tanks have their role set to tank.  Other wrath addons already use tank roles for raid frames/name plates.  

I drew a bit off of the pull request #594 

It has been working for me although more testing would be nice.  