### PR TITLE
Update guildtext.lua to fix lua error

### DIFF
--- a/Kui_Nameplates/plugins/guildtext.lua
+++ b/Kui_Nameplates/plugins/guildtext.lua
@@ -8,7 +8,7 @@ local UnitIsPlayer,UnitIsOtherPlayersPet,GetGuildInfo=
 
 local tooltip = CreateFrame('GameTooltip','KNPNPCTitleTooltip',nil,'GameTooltipTemplate')
 local cb_tooltips
-local pattern,pattern_type,pattern_class,pattern_class_type
+local pattern,pattern_type,pattern_class_type
 
 -- messages ####################################################################
 function mod:Show(f)
@@ -32,10 +32,9 @@ function mod:Show(f)
 
         -- ignore strings matching TOOLTIP_UNIT_LEVEL
         if not gtext or
-           gtext:find(pattern) or
-           gtext:find(pattern_type) or
-           gtext:find(pattern_class) or
-           gtext:find(pattern_class_type)
+           (pattern and gtext:find(pattern)) or
+           (pattern_type and gtext:find(pattern_type)) or
+           (pattern_class_type and gtext:find(pattern_class_type))
         then
             return
         end
@@ -52,11 +51,11 @@ function mod:Initialise()
     -- generate matching pattern for locale
     -- replace format substitution with match anything
     local function FixPattern(source)
+        if not source then return end
         return "^"..source:gsub("%%.%$?s?",".+").."$"
     end
     pattern = FixPattern(TOOLTIP_UNIT_LEVEL)
     pattern_type = FixPattern(TOOLTIP_UNIT_LEVEL_TYPE)
-    pattern_class = FixPattern(TOOLTIP_UNIT_LEVEL_CLASS)
     pattern_class_type = FixPattern(TOOLTIP_UNIT_LEVEL_CLASS_TYPE)
 end
 function mod:OnEnable()


### PR DESCRIPTION
- Fix a lua error, TOOLTIP_UNIT_LEVEL_CLASS was removed in 10.1.5.
- Added extra nil checks to cover future issues