### PR TITLE
Cataclysm support for packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Create Classic Package
         uses: BigWigsMods/packager@v2
         with:
-          args: -g wrath -m .pkgmeta-classic.yml
+          args: -g cata -m .pkgmeta-classic.yml
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Create Classic Package
         uses: BigWigsMods/packager@v2
         with:
-          args: -d -z -g wrath -m .pkgmeta-classic.yml
+          args: -d -z -g cata -m .pkgmeta-classic.yml
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Changes to Github Actions to make packages for Cataclysm instead of Wrath.