### PR TITLE
Prevent softinteract icons from being replaced

### DIFF
--- a/Kui_Nameplates/addon.lua
+++ b/Kui_Nameplates/addon.lua
@@ -91,6 +91,7 @@ function addon:NAME_PLATE_CREATED(frame)
     end
 end
 function addon:NAME_PLATE_UNIT_ADDED(unit)
+    if UnitIsUnit(unit, 'softinteract') then return end
     local f = C_NamePlate.GetNamePlateForUnit(unit)
     if not f or not f.kui then return end
 


### PR DESCRIPTION
KNP replaces certain softinteract icons with ugly zero-health nameplates.

This is true for the interact icons of fishing bobbers, mining/herb nodes, mailboxes, etc. 

Example:

<img width="239" alt="image" src="https://github.com/user-attachments/assets/bcfe8c3a-8040-401c-928e-134a0f89aba9">

In Name-only mode it gets reduced to the zero level number:

<img width="185" alt="image" src="https://github.com/user-attachments/assets/6d532baa-ac91-4b5a-8e84-5576726ef6ef">

---

The proposed change seems to fix this: 

<img width="252" alt="image" src="https://github.com/user-attachments/assets/c42150ed-c54e-4b44-8bb3-617feea2f08f">

(Nameplates of softinteractable NPCs, like merchants, are not altered.)

See also #729.