### PR TITLE
ci: use pkgmeta-classic for mists

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Create Classic Package
         uses: BigWigsMods/packager@v2
         with:
-          args: -g mists -m .pkgmeta.yml
+          args: -g mists -m .pkgmeta-classic.yml
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This uses the `.pkgmeta-classic.yml` for the Mists build.

I tested this by moving the missing `lib/*` folders into my local addon folder. Login Lua issues are resolved, and the addon works.

Fixes #764